### PR TITLE
Two test for checking Meta.enum extension.

### DIFF
--- a/dataforge-meta/src/jvmTest/kotlin/hep/dataforge/meta/MetaExtensionTest.kt
+++ b/dataforge-meta/src/jvmTest/kotlin/hep/dataforge/meta/MetaExtensionTest.kt
@@ -1,0 +1,22 @@
+package hep.dataforge.meta
+
+import org.junit.Test
+
+class MetaExtensionTest {
+
+    enum class TestEnum{
+        test
+    }
+
+    @Test
+    fun testEnum(){
+        val meta = buildMeta{"enum" to TestEnum.test}
+        meta["enum"].enum<TestEnum>()
+    }
+    @Test
+    fun testEnumByString(){
+        val meta = buildMeta{"enum" to TestEnum.test.toString()}
+        println(meta["enum"].enum<TestEnum>())
+    }
+
+}


### PR DESCRIPTION
Test `testEnum` failed.